### PR TITLE
copy plugins from original catalog

### DIFF
--- a/bom-version-catalog/src/main/kotlin/com/faendir/gradle/BomVersionCatalogBuilder.kt
+++ b/bom-version-catalog/src/main/kotlin/com/faendir/gradle/BomVersionCatalogBuilder.kt
@@ -68,6 +68,16 @@ open class BomVersionCatalogBuilder @Inject constructor(
             }
         }
         catalog.bundleAliases.forEach { alias -> intermediateBuilder.bundle(alias, catalog.getBundle(alias).components) }
+        catalog.pluginAliases.forEach { alias ->
+            val plugin = catalog.getPlugin(alias)
+            intermediateBuilder.plugin(alias, catalog.getPlugin(alias).id).apply {
+                if (plugin.versionRef != null) {
+                    versionRef(plugin.versionRef!!)
+                } else {
+                    version { plugin.version.copyTo(it) }
+                }
+            }
+        }
         maybeImportBomCatalogs(catalog, intermediateBuilder)
         return intermediateBuilder.build()
     }


### PR DESCRIPTION
Missing plugins definitions in libs.versions.toml, copy them while build just like libraries.