### PR TITLE
evaluate bom properties values defined as string interpolation ("${key}")

### DIFF
--- a/bom-version-catalog/build.gradle.kts
+++ b/bom-version-catalog/build.gradle.kts
@@ -13,8 +13,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.16.1"))
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("net.pearx.kasechange:kasechange:1.4.1")
 }
 

--- a/bom-version-catalog/src/main/kotlin/com/faendir/gradle/extensions.kt
+++ b/bom-version-catalog/src/main/kotlin/com/faendir/gradle/extensions.kt
@@ -21,6 +21,7 @@ private val MutableVersionCatalogContainer.objects: ObjectFactory
 private val MutableVersionCatalogContainer.dependencyResolutionServices: Any
     get() = accessField("dependencyResolutionServices")
 
+@Suppress("UNCHECKED_CAST")
 private fun <T> MutableVersionCatalogContainer.accessField(name: String): T {
     return this.javaClass.superclass.getDeclaredField(name).apply { isAccessible = true }.get(this) as T
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation(libs.comQuerydsl.querydslJpa)
+    implementation(libs.comFasterxmlJacksonDatatype.jacksonDatatypeJdk8)
 }
 
 tasks.getByName<Test>("test") {

--- a/test/gradle/libs.versions.toml
+++ b/test/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
-springBoot = "2.5.1"
+jackson = "2.16.1"
 querydsl = "5.0.0"
+springBoot = "2.5.1"
 
 [libraries]
+jacksonBom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 springBom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }

--- a/test/settings.gradle.kts
+++ b/test/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         createWithBomSupport("libs") {
+            fromBomAlias("jacksonBom")
             // fromBom("org.springframework.boot:spring-boot-dependencies:2.5.0")
             fromBomAlias("springBom")
         }


### PR DESCRIPTION
* jackson-bom is an example for a bom with such properties

few of its properties:
```
"jackson.version" -> "2.16.1"
"jackson.version.annotations" -> "${jackson.version}"
"jackson.version.core" -> "${jackson.version}"
"jackson.version.databind" -> "${jackson.version}"
"jackson.version.dataformat" -> "${jackson.version}"
"jackson.version.datatype" -> "${jackson.version}"
"jackson.version.jaxrs" -> "${jackson.version}"
"jackson.version.jakarta.rs" -> "${jackson.version}"
"jackson.version.jacksonjr" -> "${jackson.version}"
"jackson.version.module" -> "${jackson.version}"
"jackson.version.module.kotlin" -> "${jackson.version.module}"
"jackson.version.module.scala" -> "${jackson.version.module}"
```

evaluation directly from bom.properties resulted in 
```
\--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jackson.version} (n)
```

which fails gradle dependencies

---

added `jackson-bom` to tests gradle build