### PR TITLE
fromBomAliasesFilter - adds multiple bom aliases given a predicate

### DIFF
--- a/test/settings.gradle.kts
+++ b/test/settings.gradle.kts
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
         createWithBomSupport("libs") {
             // fromBom("org.springframework.boot:spring-boot-dependencies:2.5.0")
             fromBomAlias("springBom")
+            // fromBomAliasesFilter { alias -> alias.endsWith("Bom") }
         }
     }
 }


### PR DESCRIPTION
`fromBomAliasesFilter` - Enhancement for `fromBomAlias`
given an alias predicate to run on all library aliases, finding library aliases for which to import bom

When adding multiple bom artifacts to the catalog, need to specify each and every library alias,

Overhead is high, this list needs to be specified for each repository loading the catalog,
Moreover, maintenance is higher, when modifying the list, i.e. adding springBoot bom, would require updates on all of the repositories
```
            listOf(
                "comAmazonaws-awsJavaSdkBom",
                "ioMicrometer-micrometerBom",
                "ioNetty-nettyBom",
                "comFasterxmlJackson-jacksonBom",
                "orgGlassfishJersey-jerseyBom",
                "orgEclipseJetty-jettyBom",
                "orgJunit-junitBom",
                "orgTestcontainers-testcontainersBom",
            ).forEach { bomAlias ->
                fromBomAlias(bomAlias)
            }
```

Suggested code allows to replace the code above with:
```
            fromBomAliasesFilter { alias -> alias.endsWith("Bom") }
```




